### PR TITLE
修改继续阅读的跳转链接

### DIFF
--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -333,7 +333,7 @@ def setup(*args):
 [//]: # (    <p class="next-steps-link">尝试互动教程</p>)
 [//]: # (    <p class="next-steps-caption">适合喜欢边动手边学的读者。</p>)
 [//]: # (  </a>)
-  <a class="vt-box" href="/guide/quick-start.html">
+  <a class="vt-box" href="/docs/guide/quick-start.html">
     <p class="next-steps-link">继续阅读该指南</p>
     <p class="next-steps-caption">该指南会带你深入了解框架所有方面的细节。</p>
   </a>

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -133,7 +133,7 @@ app.mount()
 
 <div class="vt-box-container next-steps">
 
-  <a class="vt-box" href="/guide/essentials/application.html">
+  <a class="vt-box" href="/docs/guide/essentials/application.html">
     <p class="next-steps-link">继续阅读该指南</p>
     <p class="next-steps-caption">该指南会带你深入了解框架所有方面的细节。</p>
   </a>


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [ ] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [ ] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述
点击继续阅读
<img width="772" alt="image" src="https://github.com/vuepy/docs/assets/40933166/afb8514e-0e32-47ce-9a13-564ee9568a42">

会跳转到不存在的链接
<img width="701" alt="image" src="https://github.com/vuepy/docs/assets/40933166/1990c16f-6f7e-4459-b922-c754b48d76f9">

